### PR TITLE
Change to relative path

### DIFF
--- a/src/Hangfire.Tags/Resources/script.js
+++ b/src/Hangfire.Tags/Resources/script.js
@@ -14,9 +14,9 @@ $(function() {
 
         $("h1.page-header").after(tags);
 
-        $.post("/hangfire/tags/" + id, null, function (data) {
+        $.post("../../tags/" + id, null, function (data) {
             tags.empty();
-            data.forEach(function(tag) {
+            data.forEach(function (tag) {
                 tags.append("<span class=\"label label-info\">" + tag + "</span>");
             });
         });


### PR DESCRIPTION
Change to relative path to always match the resource no matter the dashboard options set in Hangfire