### PR TITLE
fixed connection leak issue

### DIFF
--- a/src/Hangfire.Tags.PostgreSql/Hangfire.Tags.PostgreSql.csproj
+++ b/src/Hangfire.Tags.PostgreSql/Hangfire.Tags.PostgreSql.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Yong Liu</Authors>
     <Company>Medidata Solutions Inc</Company>
-    <Version>1.5.0</Version>
+    <Version>1.5.1</Version>
     <Description>Support for PostgreSql for Hangfire.Tags. This separate library is required in order to search for tags, and proper cleanup.</Description>
     <Copyright />
     <PackageProjectUrl>https://github.com/face-it/Hangfire.Tags</PackageProjectUrl>

--- a/src/Hangfire.Tags.PostgreSql/PostgreSqlTagsServiceStorage.cs
+++ b/src/Hangfire.Tags.PostgreSql/PostgreSqlTagsServiceStorage.cs
@@ -44,9 +44,10 @@ namespace Hangfire.Tags.PostgreSql
                     $@"select Overlay(Key placing '' from 1 for 5) AS Tag, COUNT(*) AS Amount, CAST(ROUND(count(*) * 1.0 / @total * 100, 0) AS INT) as Percentage
 from {_options.SchemaName}.Set s where s.Key ~ (@setKey || ':' || @tag) group by s.Key";
 
-                return connection.Query<TagDto>(
+                var weightedTags = connection.Query<TagDto>(
                     sql,
                     new { setKey, tag, total });
+                return weightedTags;
             });
         }
 
@@ -56,7 +57,7 @@ from {_options.SchemaName}.Set s where s.Key ~ (@setKey || ':' || @tag) group by
             return monitoringApi.UseConnection(connection =>
             {
                 var sql =
-                    $@"select Value from {_options.SchemaName}.Set s where s.Key like @setKey + ':%' + @tag + '%'";
+                    $@"select Value from {_options.SchemaName}.Set s where s.Key like (@setKey || ':%' || @tag || '%')";
 
                 return connection.Query<string>(
                     sql,

--- a/src/Hangfire.Tags.SqlServer/Hangfire.Tags.SqlServer.csproj
+++ b/src/Hangfire.Tags.SqlServer/Hangfire.Tags.SqlServer.csproj
@@ -5,8 +5,8 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Erwin Bovendeur</Authors>
     <Company>faceit</Company>
-    <Version>1.5.0</Version>
-    <Description>Support for SQL Server for Hangfire.Tags. This seperate library is required in order to search for tags, and proper cleanup.</Description>
+    <Version>1.5.1</Version>
+    <Description>Support for SQL Server for Hangfire.Tags. This separate library is required in order to search for tags, and proper cleanup.</Description>
     <Copyright />
     <PackageProjectUrl>https://github.com/face-it/Hangfire.Tags</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/face-it/Hangfire.Tags/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/src/Hangfire.Tags/Hangfire.Tags.csproj
+++ b/src/Hangfire.Tags/Hangfire.Tags.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Erwin Bovendeur</Authors>
     <Company>faceit</Company>
-    <Version>1.5.0</Version>
+    <Version>1.5.1</Version>
     <Description>Add tags to Hangfire backgroundjobs</Description>
     <Copyright />
     <PackageProjectUrl>https://github.com/face-it/Hangfire.Tags</PackageProjectUrl>
@@ -15,8 +15,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>hangfire tags</PackageTags>
     <PackageReleaseNotes>Initial release with support for adding tags to background jobs. The tags are visible on the job details page. It's possible to select a tag, and get a list of all jobs containing the selected tag.</PackageReleaseNotes>
-    <AssemblyVersion>1.5.0.0</AssemblyVersion>
-    <FileVersion>1.5.0.0</FileVersion>
+    <AssemblyVersion>1.5.1.0</AssemblyVersion>
+    <FileVersion>1.5.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Hangfire.Tags/States/CreateJobFilter.cs
+++ b/src/Hangfire.Tags/States/CreateJobFilter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Reflection;
 using Hangfire.Client;
 using Hangfire.Tags.Attributes;
@@ -13,7 +14,9 @@ namespace Hangfire.Tags.States
 
         public void OnCreated(CreatedContext filterContext)
         {
-            var mi = filterContext.BackgroundJob.Job.Method;
+            // BackgroundJob is Nullable from CreatedContext
+            var mi = filterContext?.BackgroundJob?.Job.Method ?? throw new ArgumentException("Background Job cannot be null", nameof(filterContext));
+
             var attrs = mi.GetCustomAttributes<TagAttribute>()
                 .Union(mi.DeclaringType?.GetCustomAttributes<TagAttribute>() ?? Enumerable.Empty<TagAttribute>())
                 .SelectMany(t => t.Tag).ToList();

--- a/src/Hangfire.Tags/States/TagsCleanupStateFilter.cs
+++ b/src/Hangfire.Tags/States/TagsCleanupStateFilter.cs
@@ -8,15 +8,17 @@ namespace Hangfire.Tags.States
     {
         public void OnStateApplied(ApplyStateContext context, IWriteOnlyTransaction transaction)
         {
-            var expireTransaction = new TagExpirationTransaction(context.Storage, (JobStorageTransaction) transaction);
-            var jobid = context.BackgroundJob.Id;
+            using (var expireTransaction = new TagExpirationTransaction(context.Storage, (JobStorageTransaction)transaction))
+            {
+                var jobid = context.BackgroundJob.Id;
 
-            if (context.NewState.IsFinal)
-                // Final state, so set the tags expiration
-                expireTransaction.Expire(jobid, context.JobExpirationTimeout);
-            else
-                // Only remove tags if the job is going to be removed
-                expireTransaction.Persist(jobid);
+                if (context.NewState.IsFinal)
+                    // Final state, so set the tags expiration
+                    expireTransaction.Expire(jobid, context.JobExpirationTimeout);
+                else
+                    // Only remove tags if the job is going to be removed
+                    expireTransaction.Persist(jobid);
+            }
         }
 
         public void OnStateUnapplied(ApplyStateContext context, IWriteOnlyTransaction transaction)

--- a/src/Hangfire.Tags/Storage/ITagsMonitoringApi.cs
+++ b/src/Hangfire.Tags/Storage/ITagsMonitoringApi.cs
@@ -4,7 +4,7 @@ using Hangfire.Tags.Dashboard.Monitoring;
 
 namespace Hangfire.Tags.Storage
 {
-    internal interface ITagsMonitoringApi
+    public interface ITagsMonitoringApi
     {
         long GetTagsCount();
 

--- a/src/Hangfire.Tags/Storage/ITagsStorage.cs
+++ b/src/Hangfire.Tags/Storage/ITagsStorage.cs
@@ -7,7 +7,7 @@ namespace Hangfire.Tags.Storage
     /// <summary>
     /// Abstraction over Hangfire's storage API
     /// </summary>
-    internal interface ITagsStorage : IDisposable
+    public interface ITagsStorage : IDisposable
     {
         /// <summary>
         /// Retrieves the monitoring api for tags

--- a/src/Hangfire.Tags/Storage/TagExpirationTransaction.cs
+++ b/src/Hangfire.Tags/Storage/TagExpirationTransaction.cs
@@ -22,6 +22,7 @@ namespace Hangfire.Tags.Storage
         public void Dispose()
         {
             _transaction.Dispose();
+            _tagsStorage.Dispose();
         }
 
         public void Expire(string jobid, TimeSpan expireIn)

--- a/src/Hangfire.Tags/Storage/TagsStorage.cs
+++ b/src/Hangfire.Tags/Storage/TagsStorage.cs
@@ -7,7 +7,7 @@ using Hangfire.Tags.Dashboard.Monitoring;
 
 namespace Hangfire.Tags.Storage
 {
-    internal class TagsStorage : ITagsStorage, ITagsMonitoringApi
+    internal class TagsStorage : ITagsStorage, ITagsMonitoringApi, IDisposable
     {
         private readonly JobStorageConnection _connection;
 


### PR DESCRIPTION
**Issue:**
On enqueuing a job with BackgroudJobClient, HangfireTags initiates another connection without disposing properly. It exhausted all DB Connections. In our test case, we have 100 max connections. It failed when we enqueue 100+ jobs. 

![image](https://user-images.githubusercontent.com/13835908/80025372-893eed80-84ae-11ea-9e1d-3e02656860a2.png)
