### PR TITLE
Fix connection leak on page refresh

### DIFF
--- a/src/Hangfire.Tags.PostgreSql/Hangfire.Tags.PostgreSql.csproj
+++ b/src/Hangfire.Tags.PostgreSql/Hangfire.Tags.PostgreSql.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Yong Liu</Authors>
     <Company>Medidata Solutions Inc</Company>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <Description>Support for PostgreSql for Hangfire.Tags. This separate library is required in order to search for tags, and proper cleanup.</Description>
     <Copyright />
     <PackageProjectUrl>https://github.com/face-it/Hangfire.Tags</PackageProjectUrl>

--- a/src/Hangfire.Tags.SqlServer/Hangfire.Tags.SqlServer.csproj
+++ b/src/Hangfire.Tags.SqlServer/Hangfire.Tags.SqlServer.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Erwin Bovendeur</Authors>
     <Company>faceit</Company>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <Description>Support for SQL Server for Hangfire.Tags. This separate library is required in order to search for tags, and proper cleanup.</Description>
     <Copyright />
     <PackageProjectUrl>https://github.com/face-it/Hangfire.Tags</PackageProjectUrl>

--- a/src/Hangfire.Tags/Dashboard/TagDashboardMetrics.cs
+++ b/src/Hangfire.Tags/Dashboard/TagDashboardMetrics.cs
@@ -7,7 +7,7 @@ namespace Hangfire.Tags.Dashboard
     {
         public readonly static DashboardMetric TagsCount = new DashboardMetric("tags:count", razorPage =>
             {
-                long count = 0;
+                long count;
                 using (var tagStorage = new TagsStorage(razorPage.Storage))
                 {
                     count = tagStorage.GetTagsCount();

--- a/src/Hangfire.Tags/Dashboard/TagDashboardMetrics.cs
+++ b/src/Hangfire.Tags/Dashboard/TagDashboardMetrics.cs
@@ -1,0 +1,18 @@
+﻿using Hangfire.Dashboard;
+using Hangfire.Tags.Storage;
+
+namespace Hangfire.Tags.Dashboard
+{
+    internal static class TagDashboardMetrics
+    {
+        public readonly static DashboardMetric TagsCount = new DashboardMetric("tags:count", razorPage =>
+            {
+                long count = 0;
+                using (var tagStorage = new TagsStorage(razorPage.Storage))
+                {
+                    count = tagStorage.GetTagsCount();
+                }
+                return new Metric(count);
+            });
+    }
+}

--- a/src/Hangfire.Tags/GlobalConfigurationExtensions.cs
+++ b/src/Hangfire.Tags/GlobalConfigurationExtensions.cs
@@ -24,7 +24,7 @@ namespace Hangfire.Tags
             if (configuration == null)
                 throw new ArgumentNullException(nameof(configuration));
 
-            TagsOptions.Options = options ?? new TagsOptions {Storage = JobStorage.Current as ITagsServiceStorage};
+            TagsOptions.Options = options ?? new TagsOptions { Storage = JobStorage.Current as ITagsServiceStorage };
 
             if (TagsOptions.Options.Storage == null)
             {
@@ -42,14 +42,11 @@ namespace Hangfire.Tags
             DashboardRoutes.Routes.Add("/tags/all", new TagsDispatcher(TagsOptions.Options));
             DashboardRoutes.Routes.Add("/tags/([0-9a-z\\-]+)", new JobTagsDispatcher(TagsOptions.Options));
 
+            DashboardMetrics.AddMetric(TagDashboardMetrics.TagsCount);
             JobsSidebarMenu.Items.Add(page => new MenuItem("Tags", page.Url.To("/tags/search"))
             {
                 Active = page.RequestPath.StartsWith("/tags/search"),
-                Metric = new DashboardMetric("tags:count", razorPage =>
-                {
-                    var tagStorage = new TagsStorage(razorPage.Storage);
-                    return new Metric(tagStorage.GetTagsCount());
-                })
+                Metric = TagDashboardMetrics.TagsCount,
             });
 
             var assembly = typeof(GlobalConfigurationExtensions).Assembly;
@@ -61,8 +58,12 @@ namespace Hangfire.Tags
             var cssPath = DashboardRoutes.Routes.Contains("/css[0-9]+") ? "/css[0-9]+" : "/css[0-9]{3}";
             DashboardRoutes.Routes.Append(cssPath, new EmbeddedResourceDispatcher(assembly, "Hangfire.Tags.Resources.style.css"));
             DashboardRoutes.Routes.Append(cssPath, new DynamicCssDispatcher(TagsOptions.Options));
-
             return configuration;
+        }
+
+        public static IServiceProvider AddTags(this IServiceProvider serviceCollection)
+        {
+            return serviceCollection;
         }
     }
 }

--- a/src/Hangfire.Tags/GlobalConfigurationExtensions.cs
+++ b/src/Hangfire.Tags/GlobalConfigurationExtensions.cs
@@ -60,10 +60,5 @@ namespace Hangfire.Tags
             DashboardRoutes.Routes.Append(cssPath, new DynamicCssDispatcher(TagsOptions.Options));
             return configuration;
         }
-
-        public static IServiceProvider AddTags(this IServiceProvider serviceCollection)
-        {
-            return serviceCollection;
-        }
     }
 }

--- a/src/Hangfire.Tags/Hangfire.Tags.csproj
+++ b/src/Hangfire.Tags/Hangfire.Tags.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Erwin Bovendeur</Authors>
     <Company>faceit</Company>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <Description>Add tags to Hangfire backgroundjobs</Description>
     <Copyright />
     <PackageProjectUrl>https://github.com/face-it/Hangfire.Tags</PackageProjectUrl>


### PR DESCRIPTION
**Issues**:

1. Connection doesn't get disposed on page refresh (manually refresh hangfire page multiple times)
2. Tag count doesn't get returned when hangfire dashboard calls stats (Tags count doesn't get refreshed until a page reload)
