### PR TITLE
Add support for MySql server implementations

### DIFF
--- a/Hangfire.Tags.sln
+++ b/Hangfire.Tags.sln
@@ -17,7 +17,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hangfire.Core.MvcApplicatio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hangfire.Tags.PostgreSql", "src\Hangfire.Tags.PostgreSql\Hangfire.Tags.PostgreSql.csproj", "{11CB8A72-DC51-42D0-A7CF-F2E8EA1869EE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Tags.PostgreSql.Tests", "tests\Hangfire.Tags.PostgreSql.Tests\Hangfire.Tags.PostgreSql.Tests.csproj", "{4E4A0F27-5630-4734-A1E7-63D379D339FB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hangfire.Tags.PostgreSql.Tests", "tests\Hangfire.Tags.PostgreSql.Tests\Hangfire.Tags.PostgreSql.Tests.csproj", "{4E4A0F27-5630-4734-A1E7-63D379D339FB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Tags.MySql", "src\Hangfire.Tags.MySql\Hangfire.Tags.MySql.csproj", "{B7041AB7-9BAB-4D59-9465-0A2F6321C603}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Tags.MySql.Tests", "tests\Hangfire.Tags.MySql.Tests\Hangfire.Tags.MySql.Tests.csproj", "{B06FFE1B-D0EB-4E9F-8F53-B7D19A351F63}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,6 +57,14 @@ Global
 		{4E4A0F27-5630-4734-A1E7-63D379D339FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4E4A0F27-5630-4734-A1E7-63D379D339FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4E4A0F27-5630-4734-A1E7-63D379D339FB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7041AB7-9BAB-4D59-9465-0A2F6321C603}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7041AB7-9BAB-4D59-9465-0A2F6321C603}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7041AB7-9BAB-4D59-9465-0A2F6321C603}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7041AB7-9BAB-4D59-9465-0A2F6321C603}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B06FFE1B-D0EB-4E9F-8F53-B7D19A351F63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B06FFE1B-D0EB-4E9F-8F53-B7D19A351F63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B06FFE1B-D0EB-4E9F-8F53-B7D19A351F63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B06FFE1B-D0EB-4E9F-8F53-B7D19A351F63}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,15 +24,19 @@ build_script:
 - cmd: dotnet build tests/Hangfire.Tags.Tests -c Release
 - cmd: dotnet build src/Hangfire.Tags.PostgreSql -c Release
 - cmd: dotnet build tests/Hangfire.Tags.PostgreSql.Tests -c Release
+- cmd: dotnet build src/Hangfire.Tags.MySql -c Release
+- cmd: dotnet build tests/Hangfire.Tags.MySql.Tests -c Release
 
 after_build:
 - cmd: dotnet pack src/Hangfire.Tags -o ../../artifacts -c Release
 - cmd: dotnet pack src/Hangfire.Tags.SqlServer -o ../../artifacts -c Release
 - cmd: dotnet pack src/Hangfire.Tags.PostgreSql -o ../../artifacts -c Release
+- cmd: dotnet pack src/Hangfire.Tags.MySql -o ../../artifacts -c Release
 
 test_script:
 - cmd: dotnet test tests/Hangfire.Tags.Tests/Hangfire.Tags.Tests.csproj
 - cmd: dotnet test tests/Hangfire.Tags.PostgreSql.Tests/Hangfire.Tags.PostgreSql.Tests.csproj
+- cmd: dotnet test tests/Hangfire.Tags.MySql.Tests/Hangfire.Tags.MySql.Tests.csproj
 
 artifacts:
 - path: 'artifacts/**/*.nupkg'

--- a/samples/Hangfire.Core.MvcApplication/Hangfire.Core.MvcApplication.csproj
+++ b/samples/Hangfire.Core.MvcApplication/Hangfire.Core.MvcApplication.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -10,6 +10,7 @@
     <PackageReference Include="Hangfire" Version="1.7.8" />
     <PackageReference Include="Hangfire.Heartbeat" Version="0.5.0" />
     <PackageReference Include="Hangfire.MemoryStorage.Core" Version="1.4.0" />
+    <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.2" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.6.4.2" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
@@ -17,6 +18,7 @@
 
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Hangfire.Tags.MySql\Hangfire.Tags.MySql.csproj" />
     <ProjectReference Include="..\..\src\Hangfire.Tags.PostgreSql\Hangfire.Tags.PostgreSql.csproj" />
     <ProjectReference Include="..\..\src\Hangfire.Tags.SqlServer\Hangfire.Tags.SqlServer.csproj" />
     <ProjectReference Include="..\..\src\Hangfire.Tags\Hangfire.Tags.csproj" />

--- a/samples/Hangfire.Core.MvcApplication/Startup.cs
+++ b/samples/Hangfire.Core.MvcApplication/Startup.cs
@@ -46,6 +46,7 @@ namespace Hangfire.Core.MvcApplication
 //                });
 
 //                config.UseTagsWithPostgreSql();
+//                config.UseTagsWithMySql();
 //                var options = new TagsOptions()
 //                {
 //                    TagsListStyle = TagsListStyle.Dropdown

--- a/samples/Hangfire.Core.MvcApplication/Startup.cs
+++ b/samples/Hangfire.Core.MvcApplication/Startup.cs
@@ -59,7 +59,7 @@ namespace Hangfire.Core.MvcApplication
                 //end SqlServer Sample
 
                 //MySql Sample
-                //config.UseStorage(new MySqlStorage(Configuration.GetConnectionString("MySqlConnection"), new MySqlStorageOptions
+                //var mySqlOptions = new MySqlStorageOptions
                 //{
                 //    TransactionIsolationLevel = IsolationLevel.ReadCommitted,
                 //    QueuePollInterval = TimeSpan.FromSeconds(15),
@@ -68,13 +68,14 @@ namespace Hangfire.Core.MvcApplication
                 //    PrepareSchemaIfNecessary = true,
                 //    DashboardJobListLimit = 50000,
                 //    TransactionTimeout = TimeSpan.FromMinutes(1),
-                //    TablesPrefix = ""
-                //}));
+                //    TablesPrefix = "hangfire"
+                //};
+                //config.UseStorage(new MySqlStorage(Configuration.GetConnectionString("MySqlConnection"), mySqlOptions));
                 //var options = new TagsOptions()
                 //{
                 //    TagsListStyle = TagsListStyle.Dropdown
                 //};
-                //config.UseTagsWithMySql(options);
+                //config.UseTagsWithMySql(options,mySqlOptions);
                 //end MySql Sample
 
                 //postgreSql Sample

--- a/samples/Hangfire.Core.MvcApplication/Startup.cs
+++ b/samples/Hangfire.Core.MvcApplication/Startup.cs
@@ -4,15 +4,20 @@ using Hangfire.Common;
 using Hangfire.Dashboard;
 using Hangfire.Heartbeat;
 using Hangfire.MemoryStorage;
-using Hangfire.SqlServer;
+using Hangfire.MySql; //used with MySql Sample
+using Hangfire.PostgreSql; //used with postgreSql Sample
+using Hangfire.SqlServer; //used with SqlServer Sample
 using Hangfire.Tags;
-using Hangfire.Tags.SqlServer;
+using Hangfire.Tags.SqlServer;//used with SqlServer Sample
+using Hangfire.Tags.MySql; //used with MySql Sample
+using Hangfire.Tags.PostgreSql; //used with postgreSql Sample
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Transactions;
 
 namespace Hangfire.Core.MvcApplication
 {
@@ -38,21 +43,53 @@ namespace Hangfire.Core.MvcApplication
             services.AddHangfire(config =>
             {
                 config.UseMemoryStorage();
-//                config.UseSqlServerStorage(Configuration.GetConnectionString("DefaultConnection"), new SqlServerStorageOptions
-//                {
-//                    SlidingInvisibilityTimeout = TimeSpan.FromMinutes(5), // To enable Sliding invisibility fetching
-//                    CommandBatchMaxTimeout = TimeSpan.FromMinutes(5), // To enable command pipelining
-//                    QueuePollInterval = TimeSpan.FromTicks(1) // To reduce processing delays to minimum
-//                });
 
-//                config.UseTagsWithPostgreSql();
-//                config.UseTagsWithMySql();
-//                var options = new TagsOptions()
-//                {
-//                    TagsListStyle = TagsListStyle.Dropdown
-//                };
-//                config.UseTagsWithSql(options);
-//                config.UseNLogLogProvider();
+                //SqlServer Sample
+                config.UseSqlServerStorage(Configuration.GetConnectionString("DefaultConnection"), new SqlServerStorageOptions
+                {
+                    SlidingInvisibilityTimeout = TimeSpan.FromMinutes(5), // To enable Sliding invisibility fetching
+                    CommandBatchMaxTimeout = TimeSpan.FromMinutes(5), // To enable command pipelining
+                    QueuePollInterval = TimeSpan.FromTicks(1) // To reduce processing delays to minimum
+                });
+                var options = new TagsOptions()
+                {
+                    TagsListStyle = TagsListStyle.Dropdown
+                };
+                config.UseTagsWithSql(options);
+                //end SqlServer Sample
+
+                //MySql Sample
+                //config.UseStorage(new MySqlStorage(Configuration.GetConnectionString("MySqlConnection"), new MySqlStorageOptions
+                //{
+                //    TransactionIsolationLevel = IsolationLevel.ReadCommitted,
+                //    QueuePollInterval = TimeSpan.FromSeconds(15),
+                //    JobExpirationCheckInterval = TimeSpan.FromHours(1),
+                //    CountersAggregateInterval = TimeSpan.FromMinutes(5),
+                //    PrepareSchemaIfNecessary = true,
+                //    DashboardJobListLimit = 50000,
+                //    TransactionTimeout = TimeSpan.FromMinutes(1),
+                //    TablesPrefix = ""
+                //}));
+                //var options = new TagsOptions()
+                //{
+                //    TagsListStyle = TagsListStyle.Dropdown
+                //};
+                //config.UseTagsWithMySql(options);
+                //end MySql Sample
+
+                //postgreSql Sample
+                //config.UsePostgreSqlStorage(Configuration.GetConnectionString("PostgreSqlConnection"), new PostgreSqlStorageOptions
+                //{
+                //    QueuePollInterval = TimeSpan.FromTicks(1) // To reduce processing delays to minimum
+                //});
+                //var options = new TagsOptions()
+                //{
+                //    TagsListStyle = TagsListStyle.Dropdown
+                //};
+                //config.UseTagsWithPostgreSql();
+                //end postgreSql Sample
+
+                //config.UseNLogLogProvider();
                 config.UseHeartbeatPage(checkInterval: TimeSpan.FromSeconds(5));
             });
 

--- a/samples/Hangfire.Core.MvcApplication/appsettings.json
+++ b/samples/Hangfire.Core.MvcApplication/appsettings.json
@@ -7,6 +7,7 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=Core_Hangfire_Sample;AttachDBFilename=C:\\Temp\\Sample.mdf;Trusted_Connection=true;MultipleActiveResultSets=true",
-    "PostgreSqlConnection": "Server=localhost;Port=5432;Database=Core_Hangfire_Sample;User Id=postgres;Password=admin;"
+    "PostgreSqlConnection": "Server=localhost;Port=5432;Database=Core_Hangfire_Sample;User Id=postgres;Password=admin;",
+    "MySqlConnection": "Server=localhost;Database=Core_Hangfire_Sample;User Id=mysql;Password=admin;"
   }
 }

--- a/samples/Hangfire.Core.MvcApplication/appsettings.json
+++ b/samples/Hangfire.Core.MvcApplication/appsettings.json
@@ -8,6 +8,6 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=Core_Hangfire_Sample;AttachDBFilename=C:\\Temp\\Sample.mdf;Trusted_Connection=true;MultipleActiveResultSets=true",
     "PostgreSqlConnection": "Server=localhost;Port=5432;Database=Core_Hangfire_Sample;User Id=postgres;Password=admin;",
-    "MySqlConnection": "Server=localhost;Database=Core_Hangfire_Sample;User Id=mysql;Password=admin;"
+    "MySqlConnection": "Datasource=localhost;Database=Core_Hangfire_Sample;uid=mysql;pwd=admin;"
   }
 }

--- a/src/Hangfire.Tags.MySql/Friends.cs
+++ b/src/Hangfire.Tags.MySql/Friends.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Hangfire.Tags.MySql.Tests")]

--- a/src/Hangfire.Tags.MySql/GlobalConfigurationExtensions.cs
+++ b/src/Hangfire.Tags.MySql/GlobalConfigurationExtensions.cs
@@ -16,7 +16,7 @@ namespace Hangfire.Tags.MySql
         /// <param name="options">Options for tags</param>
         /// <param name="sqlOptions">Options for sql storage</param>
         /// <returns></returns>
-        public static IGlobalConfiguration UseTagsWithPostgreSql(this IGlobalConfiguration configuration, TagsOptions options = null, MySqlStorageOptions sqlOptions = null)
+        public static IGlobalConfiguration UseTagsWithMySql(this IGlobalConfiguration configuration, TagsOptions options = null, MySqlStorageOptions sqlOptions = null)
         {
             options = options ?? new TagsOptions();
             sqlOptions = sqlOptions ?? new MySqlStorageOptions();

--- a/src/Hangfire.Tags.MySql/GlobalConfigurationExtensions.cs
+++ b/src/Hangfire.Tags.MySql/GlobalConfigurationExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Hangfire.MySql;
+using Hangfire.Tags.MySql;
+using Hangfire.Tags.Storage;
+
+namespace Hangfire.Tags.MySql
+{
+    /// <summary>
+    /// Provides extension methods to setup Hangfire.Tags
+    /// </summary>
+    public static class GlobalConfigurationExtensions
+    {
+        /// <summary>
+        /// Configures Hangfire to use Tags.
+        /// </summary>
+        /// <param name="configuration">Global configuration</param>
+        /// <param name="options">Options for tags</param>
+        /// <param name="sqlOptions">Options for sql storage</param>
+        /// <returns></returns>
+        public static IGlobalConfiguration UseTagsWithPostgreSql(this IGlobalConfiguration configuration, TagsOptions options = null, MySqlStorageOptions sqlOptions = null)
+        {
+            options = options ?? new TagsOptions();
+            sqlOptions = sqlOptions ?? new MySqlStorageOptions();
+
+            options.Storage = new MySqlTagsServiceStorage(sqlOptions);
+
+            TagsServiceStorage.Current = options.Storage;
+
+            var config = configuration.UseTags(options);
+            return config;
+        }
+    }
+}

--- a/src/Hangfire.Tags.MySql/Hangfire.Tags.MySql.csproj
+++ b/src/Hangfire.Tags.MySql/Hangfire.Tags.MySql.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <Authors>Adam Taylor</Authors>
+    <Company>No-Lyfe Media</Company>
+    <Version>1.0.0</Version>
+    <Description>Support for MySql for Hangfire.Tags. This separate library is required in order to search for tags, and proper cleanup.</Description>
+    <Copyright />
+    <PackageProjectUrl>https://github.com/face-it/Hangfire.Tags</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/face-it/Hangfire.Tags/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/face-it/Hangfire.Tags/master/Icon.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/face-it/Hangfire.Tags</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
+    <PackageTags>hangfire tags MySql</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Hangfire.Tags\Hangfire.Tags.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Hangfire.Tags.MySql/MySqlTagsMonitoringApi.cs
+++ b/src/Hangfire.Tags.MySql/MySqlTagsMonitoringApi.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Data.Common;
+using System.Reflection;
+using Hangfire.Storage;
+
+namespace Hangfire.Tags.MySql
+{
+    public class MySqlTagsMonitoringApi
+    {
+        private readonly IMonitoringApi _monitoringApi;
+
+        private static Type _type;
+
+        private static MethodInfo _useConnection;
+
+        public MySqlTagsMonitoringApi(IMonitoringApi monitoringApi)
+        {
+            if (monitoringApi.GetType().Name != "MySqlMonitoringApi")
+            {
+                throw new ArgumentException("The monitor API is not implemented using MySql", nameof(monitoringApi));
+            }
+
+            _monitoringApi = monitoringApi;
+            // Other transaction type, clear cached methods
+            if (_type != monitoringApi.GetType())
+            {
+                _useConnection = null;
+
+                _type = monitoringApi.GetType();
+            }
+
+            if (_useConnection == null)
+                _useConnection = monitoringApi.GetType().GetTypeInfo().GetMethod(nameof(UseConnection),
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (_useConnection == null)
+                throw new ArgumentException("The function UseConnection cannot be found.");
+        }
+
+        public T UseConnection<T>(Func<DbConnection, T> action)
+        {
+            var method = _useConnection.MakeGenericMethod(typeof(T));
+            return (T)method.Invoke(_monitoringApi, new object[] { action });
+        }
+    }
+}

--- a/src/Hangfire.Tags.MySql/MySqlTagsServiceStorage.cs
+++ b/src/Hangfire.Tags.MySql/MySqlTagsServiceStorage.cs
@@ -92,7 +92,7 @@ from `{_options.TablesPrefix}Set` s where s.Key {keyClause} group by s.Key";
                 {
                     //not tested, but original SQLServer query updated to reflect MySql's version of (nolock) and MySql not supporting (forceseek)
                     var jobsSql =
-                        $@";SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+                        $@"SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 with cte as 
 (
   select j.Id, row_number() over (order by j.Id desc) as row_num
@@ -124,7 +124,7 @@ SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ ;";
                 {
                     //fallback for older MySql servers
                     var jobsSql =
-                        $@";SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+                        $@"SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
                     SET @rownum=0;
                     CREATE TEMPORARY TABLE cte
                       select Id, @rownum:=@rownum+1 as row_num FROM (
@@ -190,7 +190,7 @@ SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ ;";
             {
                 //not tested, but original SQLServer query updated to reflect MySql's version of (nolock) and MySql not supporting (forceseek)
                 var jobsSql =
-                $@";SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;with cte as
+                $@"SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;with cte as
 (
   select j.Id, row_number() over (order by j.Id desc) as row_num
   from `{_options.TablesPrefix}Job` j";
@@ -203,7 +203,7 @@ SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ ;";
 
                 jobsSql +=
                     $@"
-  where (@stateName IS NULL OR LEN(@stateName)=0 OR j.StateName=@stateName)
+  where (@stateName IS NULL OR LENGTH(@stateName)=0 OR j.StateName=@stateName)
 )
 select count(*)
 from `{_options.TablesPrefix}Job` j
@@ -219,7 +219,7 @@ SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;";
             {
                 //fallback for older MySql servers
                 var jobsSql =
-                $@";SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+                $@"SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SET @rownum=0;
 CREATE TEMPORARY TABLE cte
 select Id, @rownum:=@rownum+1 as row_num FROM (
@@ -234,7 +234,7 @@ select Id, @rownum:=@rownum+1 as row_num FROM (
 
                 jobsSql +=
                     $@"
-  where (@stateName IS NULL OR LEN(@stateName)=0 OR j.StateName=@stateName)
+  where (@stateName IS NULL OR LENGTH(@stateName)=0 OR j.StateName=@stateName)
 order by j.Id DESC) t1, (select @rownum:=0) t2;
 select count(*)
 from `{_options.TablesPrefix}Job` j
@@ -266,7 +266,7 @@ SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;";
             {
                 //not tested, but original SQLServer query updated to reflect MySql's version of (nolock) and MySql not supporting (forceseek)
                 var jobsSql =
-                $@";SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;with cte as
+                $@"SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;with cte as
 (
   select j.Id, row_number() over (order by j.Id desc) as row_num
   from `{_options.TablesPrefix}Job` j";
@@ -279,7 +279,7 @@ SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;";
 
                 jobsSql +=
     $@"
-  where (@stateName IS NULL OR LEN(@stateName) = 0 OR j.StateName=@stateName)
+  where (@stateName IS NULL OR LENGTH(@stateName) = 0 OR j.StateName=@stateName)
 )
 select j.*, s.Reason as StateReason, s.Data as StateData
 from `{_options.TablesPrefix}Job` j
@@ -295,12 +295,13 @@ SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;";
                     .ToList();
 
                 return DeserializeJobs(jobs, selector);
-            } else
+            }
+            else
             {
                 //fallback for older MySql servers
                 var jobsSql =
-                                $@";SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-@SET @rownum=0;
+                                $@"SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+SET @rownum=0;
 CREATE TEMPORARY TABLE cte
   select Id, @rownum:=@rownum+1 as row_num FROM (
   select j.Id
@@ -314,8 +315,8 @@ CREATE TEMPORARY TABLE cte
 
                 jobsSql +=
     $@"
-  where (@stateName IS NULL OR LEN(@stateName) = 0 OR j.StateName=@stateName
-  order by j.Id desc) t1, (select @rownum:0) t2;
+  where (@stateName IS NULL OR LENGTH(@stateName) = 0 OR j.StateName=@stateName)
+  order by j.Id desc) t1, (select @rownum:=0) t2;
 
 select j.*, s.Reason as StateReason, s.Data as StateData
 from `{_options.TablesPrefix}Job` j

--- a/src/Hangfire.Tags.MySql/MySqlTagsServiceStorage.cs
+++ b/src/Hangfire.Tags.MySql/MySqlTagsServiceStorage.cs
@@ -1,0 +1,266 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using Dapper;
+using Hangfire.Common;
+using Hangfire.MySql;
+using Hangfire.Storage;
+using Hangfire.Storage.Monitoring;
+using Hangfire.Tags.Dashboard.Monitoring;
+using Hangfire.Tags.MySql;
+using Hangfire.Tags.Storage;
+
+namespace Hangfire.Tags.MySql
+{
+    public class MySqlTagsServiceStorage : ITagsServiceStorage
+    {
+        private readonly MySqlStorageOptions _options;
+
+        private MySqlTagsMonitoringApi MonitoringApi => new MySqlTagsMonitoringApi(JobStorage.Current.GetMonitoringApi());
+
+        public MySqlTagsServiceStorage(MySqlStorageOptions options)
+        {
+            _options = options;
+        }
+
+        public ITagsTransaction GetTransaction(IWriteOnlyTransaction transaction)
+        {
+            return new MySqlTagsTransaction(_options, transaction);
+        }
+
+        public IEnumerable<TagDto> SearchWeightedTags(string tag, string setKey)
+        {
+            var monitoringApi = MonitoringApi;
+            return monitoringApi.UseConnection(connection =>
+            {
+                if (string.IsNullOrEmpty(tag))
+                    tag = "[^0-9]"; // Exclude tags:<id> entries
+
+                var sql =
+                    $@"select count(*) as Amount from {_options.SchemaName}.Set s where s.Key ~ (@setKey || ':' || @tag) ";
+                var total = connection.ExecuteScalar<int>(sql, new { setKey, tag });
+
+                sql =
+                    $@"select Overlay(Key placing '' from 1 for 5) AS Tag, COUNT(*) AS Amount, CAST(ROUND(count(*) * 1.0 / @total * 100, 0) AS INT) as Percentage
+from {_options.SchemaName}.Set s where s.Key ~ (@setKey || ':' || @tag) group by s.Key";
+
+                var weightedTags = connection.Query<TagDto>(
+                    sql,
+                    new { setKey, tag, total });
+                return weightedTags;
+            });
+        }
+
+        public IEnumerable<string> SearchTags(string tag, string setKey)
+        {
+            var monitoringApi = MonitoringApi;
+            return monitoringApi.UseConnection(connection =>
+            {
+                var sql =
+                    $@"select Value from {_options.SchemaName}.Set s where s.Key like (@setKey || ':%' || @tag || '%')";
+
+                return connection.Query<string>(
+                    sql,
+                    new { setKey, tag });
+            });
+        }
+
+        public int GetJobCount(string[] tags, string stateName = null)
+        {
+            var monitoringApi = MonitoringApi;
+            return monitoringApi.UseConnection(connection => GetJobCount(connection, tags, stateName));
+        }
+
+        public IDictionary<string, int> GetJobStateCount(string[] tags, int maxTags = 50)
+        {
+            var monitoringApi = MonitoringApi;
+            return monitoringApi.UseConnection(connection =>
+            {
+                var parameters = new Dictionary<string, object>();
+
+                var jobsSql =
+                    $@";with cte as
+(
+  select j.Id, row_number() over (order by j.Id desc) as row_num
+  from {_options.SchemaName}.Job j";
+
+                for (var i = 0; i < tags.Length; i++)
+                {
+                    parameters["tag" + i] = tags[i];
+                    jobsSql +=
+                        $"  inner join {_options.SchemaName}.Set s{i} on j.Id=s{i}.Value::BIGINT and s{i}.Key=@tag{i}";
+                }
+
+                jobsSql +=
+                    $@")
+select j.StateName AS Key, count(*) AS Value
+from {_options.SchemaName}.Job j
+inner join cte on cte.Id = j.Id
+inner join {_options.SchemaName}.State s on j.StateId = s.Id
+group by j.StateName order by count(*) desc
+limit {maxTags}";
+
+                return connection.Query<KeyValuePair<string, int>>(
+                        jobsSql,
+                        parameters)
+                    .ToDictionary(d => d.Key, d => d.Value);
+            });
+        }
+
+        public JobList<MatchingJobDto> GetMatchingJobs(string[] tags, int from, int count, string stateName = null)
+        {
+            var monitoringApi = MonitoringApi;
+            return monitoringApi.UseConnection(connection => GetJobs(connection, from, count, tags, stateName,
+                (sqlJob, job, stateData) =>
+                    new MatchingJobDto
+                    {
+                        Job = job,
+                        State = sqlJob.StateName,
+                        CreatedAt = sqlJob.CreatedAt,
+                        ResultAt = GetStateDate(stateData, sqlJob.StateName)
+                    }));
+        }
+
+        private DateTime GetStateDate(SafeDictionary<string, string> stateData, string stateName)
+        {
+            var stateDateName = stateName == "Processing" ? "StartedAt" : $"{stateName}At";
+            return DateTime.TryParse(stateData?[stateDateName], out var result) ? result.ToUniversalTime() : DateTime.MinValue;
+        }
+
+        private int GetJobCount(DbConnection connection, string[] tags, string stateName)
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                {"stateName", stateName}
+            };
+
+            var jobsSql =
+                $@";with cte as
+(
+  select j.Id, row_number() over (order by j.Id desc) as row_num
+  from {_options.SchemaName}.Job j ";
+
+            for (var i = 0; i < tags.Length; i++)
+            {
+                parameters["tag" + i] = tags[i];
+                jobsSql += $" inner join {_options.SchemaName}.Set s{i} on j.Id= s{i}.Value::bigint and s{i}.Key=@tag{i}";
+            }
+
+            jobsSql +=
+                $@"
+  where (@stateName IS NULL OR LENGTH(@stateName)=0 OR j.StateName=@stateName)
+)
+select count(*)
+from {_options.SchemaName}.Job j
+inner join cte on cte.Id = j.Id
+left join {_options.SchemaName}.State s  on j.StateId = s.Id";
+
+            return connection.ExecuteScalar<int>(
+                jobsSql,
+                parameters);
+        }
+
+        private JobList<TDto> GetJobs<TDto>(
+            DbConnection connection, int from, int count, string[] tags, string stateName,
+            Func<SqlJob, Job, SafeDictionary<string, string>, TDto> selector)
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                { "start", from + 1 },
+                { "end", from + count },
+                { "stateName", stateName }
+            };
+
+            var jobsSql =
+                $@";with cte as
+(
+  select j.Id, row_number() over (order by j.Id desc) as row_num
+  from {_options.SchemaName}.Job j";
+
+            for (var i = 0; i < tags.Length; i++)
+            {
+                parameters["tag" + i] = tags[i];
+                jobsSql += $"  inner join {_options.SchemaName}.Set s{i} on j.Id=s{i}.Value::BIGINT and s{i}.Key=@tag{i}";
+            }
+
+            jobsSql +=
+$@"
+  where (@stateName IS NULL OR LENGTH(@stateName) = 0 OR j.StateName=@stateName)
+)
+select j.*, s.Reason as StateReason, s.Data as StateData
+from {_options.SchemaName}.Job j
+inner join cte on cte.Id = j.Id
+left join {_options.SchemaName}.State s on j.StateId = s.Id
+where cte.row_num between @start and @end
+order by j.Id desc";
+
+            var jobs = connection.Query<SqlJob>(
+                    jobsSql,
+                    parameters)
+                .ToList();
+
+            return DeserializeJobs(jobs, selector);
+        }
+
+        private static Job DeserializeJob(string invocationData, string arguments)
+        {
+            var data = InvocationData.DeserializePayload(invocationData);
+            if (!string.IsNullOrEmpty(arguments))
+                data.Arguments = arguments;
+
+            try
+            {
+                return data.DeserializeJob();
+            }
+            catch (JobLoadException)
+            {
+                return null;
+            }
+        }
+
+        private static JobList<TDto> DeserializeJobs<TDto>(
+            ICollection<SqlJob> jobs,
+            Func<SqlJob, Job, SafeDictionary<string, string>, TDto> selector)
+        {
+            var result = new List<KeyValuePair<string, TDto>>(jobs.Count);
+
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            foreach (var job in jobs)
+            {
+                var dto = default(TDto);
+
+                if (job.InvocationData != null)
+                {
+                    var deserializedData = SerializationHelper.Deserialize<Dictionary<string, string>>(job.StateData);
+                    var stateData = deserializedData != null
+                        ? new SafeDictionary<string, string>(deserializedData, StringComparer.OrdinalIgnoreCase)
+                        : null;
+
+                    dto = selector(job, DeserializeJob(job.InvocationData, job.Arguments), stateData);
+                }
+
+                result.Add(new KeyValuePair<string, TDto>(job.Id.ToString(), dto));
+            }
+
+            return new JobList<TDto>(result);
+        }
+
+        /// <summary>
+        /// Overloaded dictionary that doesn't throw if given an invalid key Fixes issues such as https://github.com/HangfireIO/Hangfire/issues/871
+        /// </summary>
+        private class SafeDictionary<TKey, TValue> : Dictionary<TKey, TValue>
+        {
+            public SafeDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer)
+                : base(dictionary, comparer)
+            {
+            }
+
+            public new TValue this[TKey i]
+            {
+                get => ContainsKey(i) ? base[i] : default;
+                set => base[i] = value;
+            }
+        }
+    }
+}

--- a/src/Hangfire.Tags.MySql/MySqlTagsServiceStorage.cs
+++ b/src/Hangfire.Tags.MySql/MySqlTagsServiceStorage.cs
@@ -38,12 +38,12 @@ namespace Hangfire.Tags.MySql
                     tag = "[^0-9]"; // Exclude tags:<id> entries
 
                 var sql =
-                    $@"select count(*) as Amount from `{_options.TablesPrefix}Set` s where s.Key like @setKey + ':%' + @tag + '%'";
+                    $@"select count(*) as Amount from `{_options.TablesPrefix}Set` s where s.Key like CONCAT(@setKey,':%',@tag,'%')";
                 var total = connection.ExecuteScalar<int>(sql, new { setKey, tag });
 
                 sql =
                     $@"select INSERT(`Key`, 1, 5, '') AS `Tag`, COUNT(*) AS `Amount`, CAST(ROUND(count(*) * 1.0 / @total * 100, 0) AS SIGNED) as `Percentage` 
-from `{_options.TablesPrefix}Set` s where s.Key like @setKey + ':%' + @tag + '%' group by s.Key";
+from `{_options.TablesPrefix}Set` s where s.Key like CONCAT(@setKey,':%',@tag,'%') group by s.Key";
 
                 var weightedTags = connection.Query<TagDto>(
                     sql,
@@ -58,7 +58,7 @@ from `{_options.TablesPrefix}Set` s where s.Key like @setKey + ':%' + @tag + '%'
             return monitoringApi.UseConnection(connection =>
             {
                 var sql =
-                    $@"select `Value` from `{_options.TablesPrefix}Set` s where s.Key like @setKey + ':%' + @tag + '%'";
+                    $@"select `Value` from `{_options.TablesPrefix}Set` s where s.Key like CONCAT(@setKey,':%',@tag,'%')";
 
                 return connection.Query<string>(
                     sql,

--- a/src/Hangfire.Tags.MySql/MySqlTagsTransaction.cs
+++ b/src/Hangfire.Tags.MySql/MySqlTagsTransaction.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Reflection;
+using Hangfire.MySql;
+using Hangfire.Storage;
+using Hangfire.Tags.Storage;
+using Dapper;
+using MySql.Data.MySqlClient;
+
+namespace Hangfire.Tags.MySql
+{
+    public class MySqlTagsTransaction : ITagsTransaction
+    {
+        private readonly MySqlStorageOptions _options;
+
+        private readonly IWriteOnlyTransaction _transaction;
+
+        private static MethodInfo _queueCommand;
+
+        public MySqlTagsTransaction(MySqlStorageOptions options, IWriteOnlyTransaction transaction)
+        {
+            if (transaction.GetType().Name != "MySqlWriteOnlyTransaction")
+                throw new ArgumentException("The transaction is not a MySql transaction", nameof(transaction));
+
+            _options = options;
+            _transaction = transaction;
+
+            if (_queueCommand == null)
+                _queueCommand = transaction.GetType().GetTypeInfo().GetMethod(nameof(QueueCommand),
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (_queueCommand == null)
+                throw new ArgumentException("The functions QueueCommand cannot be found.");
+        }
+
+        private void QueueCommand(Action<MySqlConnection> action)
+        {
+            _queueCommand.Invoke(_transaction, new object[] { action });
+        }
+
+        public void ExpireSetValue(string key, string value, TimeSpan expireIn)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+
+            var query = $@"
+update {_options.SchemaName}.Set set ExpireAt = @expireAt where Key = @key and Value = @value";
+
+            QueueCommand((connection) => connection.Execute(
+                    query,
+                    new
+                    {
+                        key,
+                        value,
+                        expireAt = DateTime.UtcNow.Add(expireIn)
+                    }));
+        }
+
+        public void PersistSetValue(string key, string value)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+
+            string query = $@"
+update {_options.SchemaName}.Set set ExpireAt = null where Key = @key and Value = @value";
+
+            QueueCommand((connection) => connection.Execute(query,
+                 new { key, value }));
+        }
+    }
+}

--- a/src/Hangfire.Tags.MySql/MySqlTagsTransaction.cs
+++ b/src/Hangfire.Tags.MySql/MySqlTagsTransaction.cs
@@ -42,7 +42,7 @@ namespace Hangfire.Tags.MySql
             if (key == null) throw new ArgumentNullException(nameof(key));
 
             var query = $@"
-update {_options.SchemaName}.Set set ExpireAt = @expireAt where Key = @key and Value = @value";
+update `{_options.TablesPrefix}Set` set ExpireAt = @expireAt where Key = @key and Value = @value";
 
             QueueCommand((connection) => connection.Execute(
                     query,
@@ -59,7 +59,7 @@ update {_options.SchemaName}.Set set ExpireAt = @expireAt where Key = @key and V
             if (key == null) throw new ArgumentNullException(nameof(key));
 
             string query = $@"
-update {_options.SchemaName}.Set set ExpireAt = null where Key = @key and Value = @value";
+update `{_options.TablesPrefix}Set` set ExpireAt = null where Key = @key and Value = @value";
 
             QueueCommand((connection) => connection.Execute(query,
                  new { key, value }));

--- a/src/Hangfire.Tags.MySql/MySqlTagsTransaction.cs
+++ b/src/Hangfire.Tags.MySql/MySqlTagsTransaction.cs
@@ -42,7 +42,7 @@ namespace Hangfire.Tags.MySql
             if (key == null) throw new ArgumentNullException(nameof(key));
 
             var query = $@"
-update `{_options.TablesPrefix}Set` set ExpireAt = @expireAt where Key = @key and Value = @value";
+update `{_options.TablesPrefix}Set` set ExpireAt = @expireAt where `Key` = @key and Value = @value";
 
             QueueCommand((connection) => connection.Execute(
                     query,
@@ -59,7 +59,7 @@ update `{_options.TablesPrefix}Set` set ExpireAt = @expireAt where Key = @key an
             if (key == null) throw new ArgumentNullException(nameof(key));
 
             string query = $@"
-update `{_options.TablesPrefix}Set` set ExpireAt = null where Key = @key and Value = @value";
+update `{_options.TablesPrefix}Set` set ExpireAt = null where `Key` = @key and Value = @value";
 
             QueueCommand((connection) => connection.Execute(query,
                  new { key, value }));

--- a/src/Hangfire.Tags.MySql/SqlJob.cs
+++ b/src/Hangfire.Tags.MySql/SqlJob.cs
@@ -1,0 +1,41 @@
+﻿// https://github.com/arnoldasgudas/Hangfire.MySqlStorage/blob/master/Hangfire.MySql/Entities/SqlJob.cs
+// This file is part of Hangfire.MySqlStorage.
+// Copyright � 2018 Arnold Asgudas <https://github.com/arnoldasgudas/Hangfire.MySqlStorage>.
+//
+// Hangfire.MySqlStorage is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, either version 3
+// of the License, or any later version.
+//
+// Hangfire.MySqlStorage  is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with Hangfire.PostgreSql. If not, see <http://www.gnu.org/licenses/>.
+//
+// This work is based on the work of Sergey Odinokov, author of
+// Hangfire. <http://hangfire.io/>
+//
+//    Special thanks goes to him.
+
+using System;
+
+namespace Hangfire.Tags.MySql
+{
+    internal class SqlJob
+    {
+        public int Id { get; set; }
+        public string InvocationData { get; set; }
+        public string Arguments { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime ExpireAt { get; set; }
+
+        public DateTime? FetchedAt { get; set; }
+
+        public string StateName { get; set; }
+        public string StateReason { get; set; }
+        public string StateData { get; set; }
+    }
+}

--- a/tests/Hangfire.Tags.MySql.Tests/Hangfire.Tags.MySql.Tests.csproj
+++ b/tests/Hangfire.Tags.MySql.Tests/Hangfire.Tags.MySql.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hangfire.Tags.MySql\Hangfire.Tags.MySql.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Hangfire.Tags.MySql.Tests/MySqlTagsMonitoringApiNegativeTests.cs
+++ b/tests/Hangfire.Tags.MySql.Tests/MySqlTagsMonitoringApiNegativeTests.cs
@@ -1,0 +1,152 @@
+using FluentAssertions;
+using Hangfire.Storage;
+using Hangfire.Storage.Monitoring;
+using Moq;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Hangfire.Tags.MySql.Tests
+{
+    public class MySqlTagsMonitoringApiNegativeTests
+    {
+        [Fact]
+        public void WhenTypeDoesNotMatch_ThenThrow()
+        {
+            // Arrange
+            var monitoringApiMock = Mock.Of<IMonitoringApi>();
+
+            // Act
+            Action act = () => new MySqlTagsMonitoringApi(monitoringApiMock);
+
+            // Assert
+            act.Should().Throw<Exception>("Monitoring api is not MySqlMonitoringApi type").WithMessage("The monitor API is not implemented using MySql*");
+        }
+
+        [Fact]
+        public void WhenUseConnectionMethodIsNotInTheInstance_ThenThrow()
+        {
+            // Arrange
+            var fakeImplementation = new PostgreSqlMonitoringApi();
+
+            // Act
+            Action act = () => new MySqlTagsMonitoringApi(fakeImplementation);
+
+            // Assert
+            act.Should().Throw<ArgumentException>("Api doesn't have UseConnection method").WithMessage("The function UseConnection cannot be found.");
+        }
+
+        private class PostgreSqlMonitoringApi : IMonitoringApi
+        {
+            public JobList<DeletedJobDto> DeletedJobs(int from, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long DeletedListCount()
+            {
+                throw new NotImplementedException();
+            }
+
+            public long EnqueuedCount(string queue)
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobList<EnqueuedJobDto> EnqueuedJobs(string queue, int from, int perPage)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDictionary<DateTime, long> FailedByDatesCount()
+            {
+                throw new NotImplementedException();
+            }
+
+            public long FailedCount()
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobList<FailedJobDto> FailedJobs(int from, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long FetchedCount(string queue)
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobList<FetchedJobDto> FetchedJobs(string queue, int from, int perPage)
+            {
+                throw new NotImplementedException();
+            }
+
+            public StatisticsDto GetStatistics()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDictionary<DateTime, long> HourlyFailedJobs()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDictionary<DateTime, long> HourlySucceededJobs()
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobDetailsDto JobDetails(string jobId)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long ProcessingCount()
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobList<ProcessingJobDto> ProcessingJobs(int from, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IList<QueueWithTopEnqueuedJobsDto> Queues()
+            {
+                throw new NotImplementedException();
+            }
+
+            public long ScheduledCount()
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobList<ScheduledJobDto> ScheduledJobs(int from, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IList<ServerDto> Servers()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDictionary<DateTime, long> SucceededByDatesCount()
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobList<SucceededJobDto> SucceededJobs(int from, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long SucceededListCount()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/tests/Hangfire.Tags.MySql.Tests/MySqlTagsMonitoringApiNegativeTests.cs
+++ b/tests/Hangfire.Tags.MySql.Tests/MySqlTagsMonitoringApiNegativeTests.cs
@@ -27,7 +27,7 @@ namespace Hangfire.Tags.MySql.Tests
         public void WhenUseConnectionMethodIsNotInTheInstance_ThenThrow()
         {
             // Arrange
-            var fakeImplementation = new PostgreSqlMonitoringApi();
+            var fakeImplementation = new MySqlMonitoringApi();
 
             // Act
             Action act = () => new MySqlTagsMonitoringApi(fakeImplementation);
@@ -36,7 +36,7 @@ namespace Hangfire.Tags.MySql.Tests
             act.Should().Throw<ArgumentException>("Api doesn't have UseConnection method").WithMessage("The function UseConnection cannot be found.");
         }
 
-        private class PostgreSqlMonitoringApi : IMonitoringApi
+        private class MySqlMonitoringApi : IMonitoringApi
         {
             public JobList<DeletedJobDto> DeletedJobs(int from, int count)
             {

--- a/tests/Hangfire.Tags.MySql.Tests/MySqlTagsMonitoringApiPostiveTests.cs
+++ b/tests/Hangfire.Tags.MySql.Tests/MySqlTagsMonitoringApiPostiveTests.cs
@@ -1,0 +1,162 @@
+﻿using FluentAssertions;
+using Hangfire.Storage;
+using Hangfire.Storage.Monitoring;
+using Hangfire.Tags.MySql;
+using MySql.Data.MySqlClient;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Hangfire.Tags.MySql.Tests
+{
+    public class MySqlTagsMonitoringApiPostiveTests
+    {
+        [Fact]
+        public void WhenTypeContainsUseConnection_ThenNotThrow()
+        {
+            // Arrange
+            var fakeImplementation = new PostgreSqlMonitoringApi();
+
+            // Act
+            Action act = () => new MySqlTagsMonitoringApi(fakeImplementation);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void WhenTypeContainsUseConnection_ThenNotThrow1()
+        {
+            // Arrange
+            var fakeImplementation = new PostgreSqlMonitoringApi();
+
+            // Act
+            var api = new MySqlTagsMonitoringApi(fakeImplementation);
+            api.UseConnection((con) => con.CreateCommand());
+
+            // Assert
+            fakeImplementation.NumberOfCalls.Should().Be(1);
+        }
+
+        private class PostgreSqlMonitoringApi : IMonitoringApi
+        {
+            public int NumberOfCalls = 0;
+
+            private T UseConnection<T>(Func<MySqlConnection, T> action)
+            {
+                NumberOfCalls++;
+                return action(new MySqlConnection());
+            }
+
+            public JobList<DeletedJobDto> DeletedJobs(int from, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long DeletedListCount()
+            {
+                throw new NotImplementedException();
+            }
+
+            public long EnqueuedCount(string queue)
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobList<EnqueuedJobDto> EnqueuedJobs(string queue, int from, int perPage)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDictionary<DateTime, long> FailedByDatesCount()
+            {
+                throw new NotImplementedException();
+            }
+
+            public long FailedCount()
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobList<FailedJobDto> FailedJobs(int from, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long FetchedCount(string queue)
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobList<FetchedJobDto> FetchedJobs(string queue, int from, int perPage)
+            {
+                throw new NotImplementedException();
+            }
+
+            public StatisticsDto GetStatistics()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDictionary<DateTime, long> HourlyFailedJobs()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDictionary<DateTime, long> HourlySucceededJobs()
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobDetailsDto JobDetails(string jobId)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long ProcessingCount()
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobList<ProcessingJobDto> ProcessingJobs(int from, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IList<QueueWithTopEnqueuedJobsDto> Queues()
+            {
+                throw new NotImplementedException();
+            }
+
+            public long ScheduledCount()
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobList<ScheduledJobDto> ScheduledJobs(int from, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IList<ServerDto> Servers()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDictionary<DateTime, long> SucceededByDatesCount()
+            {
+                throw new NotImplementedException();
+            }
+
+            public JobList<SucceededJobDto> SucceededJobs(int from, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long SucceededListCount()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/tests/Hangfire.Tags.MySql.Tests/MySqlTagsMonitoringApiPostiveTests.cs
+++ b/tests/Hangfire.Tags.MySql.Tests/MySqlTagsMonitoringApiPostiveTests.cs
@@ -15,7 +15,7 @@ namespace Hangfire.Tags.MySql.Tests
         public void WhenTypeContainsUseConnection_ThenNotThrow()
         {
             // Arrange
-            var fakeImplementation = new PostgreSqlMonitoringApi();
+            var fakeImplementation = new MySqlMonitoringApi();
 
             // Act
             Action act = () => new MySqlTagsMonitoringApi(fakeImplementation);
@@ -28,7 +28,7 @@ namespace Hangfire.Tags.MySql.Tests
         public void WhenTypeContainsUseConnection_ThenNotThrow1()
         {
             // Arrange
-            var fakeImplementation = new PostgreSqlMonitoringApi();
+            var fakeImplementation = new MySqlMonitoringApi();
 
             // Act
             var api = new MySqlTagsMonitoringApi(fakeImplementation);
@@ -38,7 +38,7 @@ namespace Hangfire.Tags.MySql.Tests
             fakeImplementation.NumberOfCalls.Should().Be(1);
         }
 
-        private class PostgreSqlMonitoringApi : IMonitoringApi
+        private class MySqlMonitoringApi : IMonitoringApi
         {
             public int NumberOfCalls = 0;
 


### PR DESCRIPTION
Added support for both MySql version 8+ as well as MySql versions older than 8 via Hangfire.MySqlServer package.  Main difference is 8+ support CTEs and row_number() while older versions don't and need a workaround.  Tested on MySql version 5.7.24.