### PR TITLE
Update CreateJobFilter.cs

### DIFF
--- a/src/Hangfire.Tags/States/CreateJobFilter.cs
+++ b/src/Hangfire.Tags/States/CreateJobFilter.cs
@@ -14,8 +14,7 @@ namespace Hangfire.Tags.States
 
         public void OnCreated(CreatedContext filterContext)
         {
-            // BackgroundJob is Nullable from CreatedContext
-            var mi = filterContext?.BackgroundJob?.Job.Method ?? throw new ArgumentException("Background Job cannot be null", nameof(filterContext));
+            var mi = filterContext.Job.Method;
 
             var attrs = mi.GetCustomAttributes<TagAttribute>()
                 .Union(mi.DeclaringType?.GetCustomAttributes<TagAttribute>() ?? Enumerable.Empty<TagAttribute>())
@@ -23,6 +22,9 @@ namespace Hangfire.Tags.States
 
             if (!attrs.Any())
                 return;
+
+            if (filterContext.BackgroundJob?.Id == null)
+                throw new ArgumentException("Background Job cannot be null", nameof(filterContext));
 
             var args = filterContext.Job.Args.ToArray();
             var tags = attrs.Select(tag => string.Format(tag, args)).Where(a => !string.IsNullOrEmpty(a));


### PR DESCRIPTION
BackgroundJob is always null when using batch functionality from Hangfire.Pro packages. For this reason we cannot use TagAttribute to decorate the job method.
This change allows to not fail the job in such case when there is no TagAttribute decorating the method and backward compatibility with users who are using it.