### PR TITLE
Proposal to allow for pointing to a specified job storage

### DIFF
--- a/src/Hangfire.Tags/Extensions/HangfireExtensions.cs
+++ b/src/Hangfire.Tags/Extensions/HangfireExtensions.cs
@@ -40,5 +40,20 @@ namespace Hangfire.Tags
             context.BackgroundJob.Id.AddTags(tags);
             return context;
         }
+
+        public static PerformContext AddTags(this PerformContext context, JobStorage jobStorage = null, params string[] tags)
+        {
+            if (jobStorage == null)
+            {
+                jobStorage = JobStorage.Current;
+            }
+
+            using (var storage = new TagsStorage(jobStorage))
+            {
+                storage.AddTags(context.BackgroundJob.Id, tags);
+            }
+
+            return context;
+        }
     }
 }


### PR DESCRIPTION
We've ran into an issue where we've had two background job servers running on a hosted service.
I was not able to configure it via Global Configuration as it would override the config for other server.
We've managed to do it by adding an overload to AddTags method which let us point to a specific jobstorage.