### PR TITLE
Fix issue QueueCommand and AddCommand cannot be found error hangfire_182

### DIFF
--- a/src/FaceIT.Hangfire.Tags.SqlServer/FaceIT.Hangfire.Tags.SqlServer.csproj
+++ b/src/FaceIT.Hangfire.Tags.SqlServer/FaceIT.Hangfire.Tags.SqlServer.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Erwin Bovendeur</Authors>
     <Company>faceit</Company>
-    <Version>1.9.0-beta.2</Version>
+    <Version>1.9.0-beta.3</Version>
     <Description>Support for SQL Server for Hangfire.Tags. This seperate library is required in order to search for tags, and proper cleanup.</Description>
     <Copyright />
     <PackageProjectUrl>https://github.com/face-it/Hangfire.Tags</PackageProjectUrl>

--- a/src/FaceIT.Hangfire.Tags.SqlServer/SqlTagsTransaction.cs
+++ b/src/FaceIT.Hangfire.Tags.SqlServer/SqlTagsTransaction.cs
@@ -61,7 +61,7 @@ namespace Hangfire.Tags.SqlServer
             if (_addCommand == null)
             {
                 _addCommand = transaction.GetType().GetTypeInfo().GetMethod(nameof(AddCommand),
-                    BindingFlags.NonPublic | BindingFlags.Instance);
+                    BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
                 _addCommand = _addCommand?.MakeGenericMethod(typeof(string));
             }
 


### PR DESCRIPTION
With the new `Hangfire.SqlServer 1.8.6` the method `AddCommand` from the class `SqlServerWriteOnlyTransaction`, was changed to `static` https://github.com/HangfireIO/Hangfire/commit/c0d6290153abca71e08834f3133222e0c110063e.

Updating to get the method with the proper `BindingFlags`, adding `BindingFlags.Static`

closes #77 

relates to #80 